### PR TITLE
Add stats on output and written data

### DIFF
--- a/src/main/java/fluentd/FluentdListener.java
+++ b/src/main/java/fluentd/FluentdListener.java
@@ -48,6 +48,10 @@ public class FluentdListener implements EventListener {
         event.put("peakUserMemoryBytes", queryCompletedEvent.getStatistics().getPeakUserMemoryBytes());
         event.put("totalBytes", queryCompletedEvent.getStatistics().getTotalBytes());
         event.put("totalRows", queryCompletedEvent.getStatistics().getTotalRows());
+        event.put("outputBytes", queryCompletedEvent.getStatistics().getOutputBytes());
+        event.put("outputRows", queryCompletedEvent.getStatistics().getOutputRows());
+        event.put("writtenBytes", queryCompletedEvent.getStatistics().getWrittenBytes());
+        event.put("writtenRows", queryCompletedEvent.getStatistics().getWrittenRows());
         event.put("cumulativeMemory", queryCompletedEvent.getStatistics().getCumulativeMemory());
         event.put("completedSplits", queryCompletedEvent.getStatistics().getCompletedSplits());
 


### PR DESCRIPTION
This PR adds outputBytes, outputRows, writtenBytes, and writtenRows to event data.
Here is an output from stdout output plugin:

```
2018-07-18 05:02:08.000000000 +0900 presto.query: {"analysisTime":719,"completedSplits":18,"source":"presto-cli","peakTotalNonRevocableMemoryBytes":0,"queryId":"20180717_200206_00001_q4p7b","cpuTime":104,"totalBytes":0,"state":"FINISHED","peakUserMemoryBytes":0,"queuedTime":0,"query":"select * from mysql.test.product limit 3","userAgent":"StatementClient/0.194","totalRows":10,"outputRows":3,"outputBytes":48,"uri":"http://10.0.1.4:8080/v1/query/20180717_200206_00001_q4p7b","writtenBytes":0,"writtenRows":0,"cumulativeMemory":0.0,"remoteClientAddress":"127.0.0.1","distributedPlanningTime":28,"createTime":1531857726803,"wallTime":393,"executionStartTime":1531857727723,"endTime":1531857728461,"user":"arabiki"}
```