### PR TITLE
Remove distributedPlanningTime

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,14 +6,14 @@
 
     <groupId>fluentd</groupId>
     <artifactId>presto-fluentd</artifactId>
-    <version>0.0.5</version>
+    <version>0.0.6</version>
 
     <dependencies>
 
         <dependency>
             <groupId>io.prestosql</groupId>
             <artifactId>presto-spi</artifactId>
-            <version>301</version>
+            <version>318</version>
         </dependency>
 
         <dependency>

--- a/src/main/java/fluentd/FluentdListener.java
+++ b/src/main/java/fluentd/FluentdListener.java
@@ -41,9 +41,6 @@ public class FluentdListener implements EventListener {
         if(queryCompletedEvent.getStatistics().getAnalysisTime().isPresent()) {
             event.put("analysisTime", queryCompletedEvent.getStatistics().getAnalysisTime().get().toMillis());
         }
-        if(queryCompletedEvent.getStatistics().getDistributedPlanningTime().isPresent()) {
-            event.put("distributedPlanningTime", queryCompletedEvent.getStatistics().getDistributedPlanningTime().get().toMillis());
-        }
         event.put("peakTotalNonRevocableMemoryBytes", queryCompletedEvent.getStatistics().getPeakTotalNonRevocableMemoryBytes());
         event.put("peakUserMemoryBytes", queryCompletedEvent.getStatistics().getPeakUserMemoryBytes());
         event.put("totalBytes", queryCompletedEvent.getStatistics().getTotalBytes());


### PR DESCRIPTION
It's no longer supported since prestosql 318
- https://github.com/prestosql/presto/commit/d258744b3ab2019a12e6ec67c0948bb6ccfab629
- https://github.com/prestosql/presto/issues/1238

Any other good idea to fix it?